### PR TITLE
Remove the pyproject.toml.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,0 @@
-[build-system]
-requires = ['cyarray', 'Cython>=0.20', 'mpi4py>=1.2', 'numpy', 'setuptools',
-            'wheel']


### PR DESCRIPTION
This causes more problems as pip's build isolation tends to lead to
strange errors as when cyarray is built and installed its dependencies
are installed into an isolated environment leading to strange looking
issues for unsuspecting users.