### PR TITLE
Remove pyproject.toml.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,0 @@
-[build-system]
-requires = [
-    "wheel",
-    "setuptools",
-    "oldest-supported-numpy",
-    "Cython>=0.20",
-    "cyarray",
-    "mpi4py>=1.2"
-]


### PR DESCRIPTION
pyproject.toml forces build isolation and without the ability to specify
build dependencies it creates more problems than it solves.  Removing it
again for now.